### PR TITLE
Quick viewport meta tag insertion

### DIFF
--- a/About/index.html
+++ b/About/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="./css/about.css">
     <link rel="stylesheet" href="./css/footer.css">
     <link rel="stylesheet" href="../master.css">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 </head>
 <body>
 


### PR DESCRIPTION
The text was appearing really small on mobile for some reason, but through SO I found that I needed to have a meta tag with content width to prevent mobile devices from trying to zoom the entire website out.