### PR TITLE
Backend user creation and score updating

### DIFF
--- a/server.js
+++ b/server.js
@@ -8,10 +8,10 @@ const app = express();
 const port = 3000;
 
 //variables for use with user/GitHub
-//const client_id = 'PUT-CLIENT-ID-HERE';
-//const client_secret = 'PUT-CLIENT-SECRET-HERE';
-const client_id = '7cb697c561a995d7c9f7';
-const client_secret = 'b017bc8ba12dcc42477de914b7e7b1f288c2e296';
+const client_id = 'PUT-CLIENT-ID-HERE';
+const client_secret = 'PUT-CLIENT-SECRET-HERE';
+//const client_id = '7cb697c561a995d7c9f7';
+//const client_secret = 'b017bc8ba12dcc42477de914b7e7b1f288c2e296';
 const user = {
     username: '',
     user_id: ''

--- a/server.js
+++ b/server.js
@@ -8,10 +8,10 @@ const app = express();
 const port = 3000;
 
 //variables for use with user/GitHub
-const client_id = 'PUT-CLIENT-ID-HERE';
-const client_secret = 'PUT-CLIENT-SECRET-HERE';
-// const clientID = '7cb697c561a995d7c9f7';
-// const clientSecret = 'b017bc8ba12dcc42477de914b7e7b1f288c2e296';
+//const client_id = 'PUT-CLIENT-ID-HERE';
+//const client_secret = 'PUT-CLIENT-SECRET-HERE';
+const client_id = '7cb697c561a995d7c9f7';
+const client_secret = 'b017bc8ba12dcc42477de914b7e7b1f288c2e296';
 const user = {
     username: '',
     user_id: ''
@@ -117,7 +117,7 @@ async function performUserLookup(user_token){
     });
     const user_json = await response.json();
     const set = await setUser(user_json.login, user_json.id);
-    return user_json.login;
+    return;
 }
 
 /*
@@ -146,6 +146,25 @@ postcondition: user is logged in/has information stored on server
 app.get('/user/login/callbackfunc', async (req,res) => {
     var access_obj = await performUserCallbackFunction(req.query.code);
     var user_obj = await performUserLookup(access_obj.access_token);
+    let user_json = getUser();
+    //database lookup/insertion
+    let db = client.db('CodeTrivia');
+    let collection = db.collection('Users');
+    var query = { "username": user_json.username, "id": user_json.user_id};
+    await collection.find(query).toArray().then(user_val => {
+        //if there is no user in the system for that username, then add one
+        console.log(user_val);
+        if(!user_val.length){
+            const user_structure = {
+                username: user_json.username,
+                id: user_json.user_id,
+                scores: []
+            };
+            collection.insertOne(user_structure);
+            console.log("Inserted a new user into the database");
+        }
+    });
+
     res.redirect('http://localhost:3000/');
 });
 

--- a/server.js
+++ b/server.js
@@ -213,15 +213,14 @@ postcondition: correct user has score updated/inserted into their score
 */
 app.post('/scores/updateScore', async (req, res) => {
 
-
     if(req.body.username == ''){
         return res.send({status: 'empty', message: 'user does not exist in database, cannot add score.'});
     }
 
     var username = req.body.username;
 
-    if(!req.body.category){
-        return res.send({status: 'cat_empty', message: 'category is empty and as such score cannot be added.'});
+    if(!req.body.category || !req.body.score){
+        return res.send({status: 'score_empty', message: 'category or score for category is empty and as such score cannot be added.'});
     }
     
     var query = { "username": username };
@@ -231,9 +230,8 @@ app.post('/scores/updateScore', async (req, res) => {
 
     var score_in_cat = false;
     await collection.findOne(query).then(response => {
-            console.log(response);
             for (item of response.scores){
-                if(response.category = req.body.category){
+                if(item.category == req.body.category){
                     score_in_cat = true;
                 }
             }


### PR DESCRIPTION
This is a PR for some endpoint updates/additions. The main things are:
- The endpoint for the user callback function for GitHub OAuth now includes an insert to the MongoDB if a user with the given username/id is not found within it.
- There is now a POST endpoint for scores/updateScore. It takes a username, category, and score. If the user is found to contain a score for the given category, it just updates with the new value, while if not it creates a new score for the category. 
These are only the endpoints, so ultimately it shouldn't mess up any client-side work, but hopefully it's fine. 